### PR TITLE
Use updated progressbar and remove legacy plugin interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@
 # You should have received a copy of the GNU Affero General Public License along
 # with git-project. If not, see <https://www.gnu.org/licenses/>.
 
-progressbar>=2.5
-pygit2>=1.15.0
+progressbar2>=4.4.2
+pygit2>=1.15.1

--- a/src/git_project/pluginmanager.py
+++ b/src/git_project/pluginmanager.py
@@ -26,11 +26,6 @@ if sys.version_info < (3, 10):
 else:
     from importlib.metadata import entry_points
 
-# TODO: Remove after transitioning git-project-core-plugins.
-import pkg_resources
-
-ENTRYPOINT = 'git_project.plugins'
-
 class PluginManager(object):
     """A Borg class responsible for discovering plugins and providing handles to
     them.
@@ -45,9 +40,6 @@ class PluginManager(object):
     def load_plugins(self, git, project):
         """Discover all plugins and instantiate them."""
         plugins = entry_points(group='git-project.plugins')
-        # TODO: Remove after transitioning git-project-core-plugins.
-        plugins.extend([entpt for entpt in
-                        pkg_resources.iter_entry_points(ENTRYPOINT)])
         for entrypoint in plugins:
             plugin_class = entrypoint.load()
             plugin = plugin_class()


### PR DESCRIPTION
We have updated git-project-core-plugins so we can remove the legacy plugin interface.

Update to the latest progressbar2.
