### PR TITLE
[git] Fix credentials callback

### DIFF
--- a/src/git_project/git.py
+++ b/src/git_project/git.py
@@ -58,10 +58,12 @@ class Git(object):
             self.null_oid = pygit2.Oid(hex='0000000000000000000000000000000000000000')
 
         def credentials(self, url, username_from_url, allowed_types):
-            if allowed_types & pygit2.credentials.GIT_CREDENTIAL_SSH_KEY:
-                return pygit2.Keypair(username_from_url, str(Path.home() / '.ssh' / 'id_rsa.pub'),
-                                      str(Path.home() / '.ssh' / 'id_rsa'), '')
-            elif allowed_types & pygit2.credentials.GIT_CREDENTIAL_USERNAME:
+            if allowed_types & pygit2.enums.CredentialType.SSH_KEY:
+                return pygit2.Keypair(
+                    username_from_url, str(Path.home() / '.ssh' / 'id_rsa.pub'),
+                    str(Path.home() / '.ssh' / 'id_rsa'), ''
+                )
+            elif allowed_types & pygit2.enums.CredentialType.USERNAME:
                 return pygit2.Username(username_from_url)
             return None
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -21,6 +21,7 @@ import os
 import git_project
 
 from pathlib import Path
+import pygit2
 import shutil
 
 def test_git_init(reset_directory,
@@ -874,3 +875,17 @@ def test_git_get_git_common_dir_renamed(reset_directory, local_repository):
 
     assert git.has_repo()
     assert Path(git.get_git_common_dir()).name == new_hidden_dir
+
+
+def test_git_remote_credentials(reset_directory):
+    callback = git_project.Git.RemoteCallbacks();
+
+    key_result = callback.credentials(
+        'ssh:me@my.org/test.git', 'me', pygit2.enums.CredentialType.SSH_KEY
+    )
+    name_result = callback.credentials(
+        'ssh:me@my.org/test.git', 'me', pygit2.enums.CredentialType.USERNAME
+    )
+
+    assert isinstance(key_result, pygit2.Keypair)
+    assert isinstance(name_result, pygit2.Username)


### PR DESCRIPTION
The credentials callback was using an outdated enum to determine the type of credentials to return.  Use the updated enums.