### PR TITLE
[substitutable] Handle missing branch

### DIFF
--- a/src/git_project/substitutable.py
+++ b/src/git_project/substitutable.py
@@ -95,7 +95,9 @@ class SubstitutableConfigObject(ConfigObject):
                     current_branch = git.refname_to_branch_name(head_name.read_text().strip())
                     break
 
-        formats['branch'] = current_branch
+        print(f'current_branch: {current_branch}')
+        if current_branch is not None:
+            formats['branch'] = current_branch
 
         # Make sure substitutions don't reference themselves, to avoid an
         # infinite loop substituting.


### PR DESCRIPTION
If we don't have a branch (for example we're in a detached HEAD state), don't add the branch to the format map.